### PR TITLE
add blocktimes for earlier specs

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -2,6 +2,5 @@
 <project version="4">
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/pb" vcs="Git" />
   </component>
 </project>

--- a/cmd/firebeacon/http/fetcher.go
+++ b/cmd/firebeacon/http/fetcher.go
@@ -65,8 +65,13 @@ func fetchRunE(logger *zap.Logger, tracer logging.Tracer) firecore.CommandExecut
 		}
 
 		latestBlockRetryInterval := sflags.MustGetDuration(cmd, "latest-block-retry-interval")
+		httpFetcher, err := blockfetcher.NewHttp(httpClient, fetchInterval, latestBlockRetryInterval, logger)
+		if err != nil {
+			return fmt.Errorf("failed to setup http blockfetcher: %w", err)
+		}
+
 		poller := blockpoller.New(
-			blockfetcher.NewHttp(httpClient, fetchInterval, latestBlockRetryInterval, logger),
+			httpFetcher,
 			blockpoller.NewFireBlockHandler("type.googleapis.com/sf.beacon.type.v1.Block"),
 			blockpoller.WithStoringState(stateDir),
 			blockpoller.WithLogger(logger),


### PR DESCRIPTION
this adds a block timestamp to phase0 and altair spec blocks. It's being calculated as `blockTimestamp = genesisTimestamp + (blockTime * slotNumber)`